### PR TITLE
Add Jenkins Server JCasC configs and initial job

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,14 @@
+FROM jenkins/jenkins:lts
+
+ENV JAVA_OPTS="-Djenkins.install.runSetupWizard=false"
+ENV CASC_JENKINS_CONFIG="/var/jenkins_home/casc.yaml"
+
+# Copy the plugin list
+COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
+
+# Install plugins using the plugin manager CLI
+RUN jenkins-plugin-cli --plugin-file /usr/share/jenkins/ref/plugins.txt
+
+# Copy the configuration files into the container
+COPY casc.yaml /var/jenkins_home/casc.yaml
+COPY jobs/seed.groovy /var/jenkins_home/seed.groovy

--- a/README.md
+++ b/README.md
@@ -1,2 +1,45 @@
-# ceph-jenkins
-Ceph Jenkins
+# Ceph Jenkins
+
+This repository provides the configuration and deployment logic for a containerized Jenkins controller used in Ceph Storage pipelines.
+
+## Getting Started
+
+### Prerequisites
+
+Before deploying the containerized controller, ensure the following requirements are met:
+
+* **Container Runtime**: Podman or Docker must be installed on the host machine.
+
+* **Configuration Files:** The following files important configuration files -
+    * `Containerfile`: To build the custom Jenkins image.
+    * `plugins.txt`: Listing required plugins.
+    * `casc.yaml`: Defining system-level configurations.
+    * `jobs/seed.groovy`: The initial script to bootstrap the job-processing logic.
+
+### Deployment Steps
+
+Deployment follows "Configuration as Code" workflow to maintain the repository as the single source of truth.
+
+1. **Build the Image:** Create the custom controller image using the provided `Containerfile`. This process pre-installs all plugins from `plugins.txt`:
+    ```sh
+    podman build -t ceph-jenkins-controller:latest .
+    ```
+2. **Launch the Controller:** Start the container with port mappings for the UI and agent communication. Ensure the persistent volume is mounted:
+    ```
+    podman run -d \
+        --name jenkins-controller \
+        -p 8080:8080 -p 50000:50000 \
+        -v jenkins_home:/var/jenkins_home \
+        ceph-jenkins-controller:latest
+    ```
+3. **Bootstrap Jobs:** Upon startup, JCasC will automatically execute `seed.groovy` to create the `Seed` job.
+
+4. **Process Project Jobs:** Run the `Seed` from the Jenkins UI, providing the relative path to your project's Groovy definitions to generate project-specific pipelines.
+
+### Logging
+
+The Ceph CI environment utilizes multiple logging layers to ensure visibility across the "controller/builder" architecture.
+
+* **Controller Logs:** Monitor the startup and JCasC initialization via `podman logs -f jenkins-controller`.
+
+* **Builder Logs:** Detailed system logs are often captured during build execution using `journalctl`.

--- a/casc.yaml
+++ b/casc.yaml
@@ -1,0 +1,7 @@
+jenkins:
+  systemMessage: "Ceph Jenkins Controller"
+  numExecutors: 1
+  mode: EXCLUSIVE
+
+jobs:
+  - file: "/var/jenkins_home/seed.groovy"

--- a/jobs/seed.groovy
+++ b/jobs/seed.groovy
@@ -1,0 +1,21 @@
+// Seed job created during the jenkins initialization
+freeStyleJob("Seed") {
+    description("Seed Job to process DSL scripts")
+
+    parameters {
+        // Default path to project directory
+        stringParam("DSL_PATH", "jobs/*.groovy", "Relative path to the project DSL script")
+    }
+
+    steps {
+        dsl {
+            // Path to process DSL scripts
+            external("${DSL_PATH}")
+            
+            // Standard persistence settings
+            removeAction("IGNORE")
+            removeViewAction("IGNORE")
+            lookupStrategy("SEED_JOB")
+        }
+    }
+}

--- a/plugins.txt
+++ b/plugins.txt
@@ -1,0 +1,4 @@
+configuration-as-code
+job-dsl
+git
+workflow-aggregator


### PR DESCRIPTION
Added below configurations files -

1. `Containerfile`: To build the custom Jenkins image.
2. `plugins.txt`: Listing required plugins.
3. `casc.yaml`: Defining system-level configurations.
4. `jobs/seed.groovy`: The initial script to bootstrap the job-processing logic.

Steps to deploy Jenkins Server -
1. **Build the Image:** Create the custom controller image using the provided `Containerfile`. This process pre-installs all plugins from `plugins.txt`:
    ```sh
    podman build -t ceph-jenkins-controller:latest .
    ```
2. **Launch the Controller:** Start the container with port mappings for the UI and agent communication. Ensure the persistent volume is mounted:
    ```
    podman run -d \
        --name jenkins-controller \
        -p 8080:8080 -p 50000:50000 \
        -v jenkins_home:/var/jenkins_home \
        ceph-jenkins-controller:latest