### PR TITLE
conf: refactor `casc.yaml` into a template using variables

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -2,10 +2,6 @@ FROM jenkins/jenkins:lts
 
 # Jenkins configurations
 ENV JAVA_OPTS="-Djenkins.install.runSetupWizard=false"
-ENV CASC_JENKINS_CONFIG="/var/jenkins_home/casc.yaml"
-
-# Default password for the initial deployment
-ENV JENKINS_ADMIN_PASSWORD="admin123"
 
 # Copy the plugin list
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
@@ -13,6 +9,17 @@ COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
 # Install plugins using the plugin manager CLI
 RUN jenkins-plugin-cli --plugin-file /usr/share/jenkins/ref/plugins.txt
 
+# Create the config directory
+USER root
+RUN mkdir -p /var/jenkins_home/casc_configs && \
+    chown -R jenkins:jenkins /var/jenkins_home/casc_configs
+USER jenkins
+
+# Copy the BASE template (the one with ${VAR} placeholders)
+COPY casc.yaml /var/jenkins_home/casc_configs/01-base-casc.yaml
+
 # Copy the configuration files into the container
-COPY casc.yaml /var/jenkins_home/casc.yaml
 COPY jobs/seed.groovy /var/jenkins_home/seed.groovy
+
+# Set jenkins config directory
+ENV CASC_JENKINS_CONFIG=/var/jenkins_home/casc_configs

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Before deploying the containerized controller, ensure the following requirements
     * `Containerfile`: To build the custom Jenkins image.
     * `plugins.txt`: Listing required plugins.
     * `casc.yaml`: Defining system-level configurations.
+    * `properties.yaml`: Actual environment settings.
     * `jobs/seed.groovy`: The initial script to bootstrap the job-processing logic.
 
 ### Deployment Steps
@@ -24,18 +25,20 @@ Deployment follows "Configuration as Code" workflow to maintain the repository a
     ```sh
     podman build -t ceph-jenkins-controller:latest .
     ```
-2. **Launch the Controller:** Start the container with port mappings for the UI and agent communication. Ensure the persistent volume is mounted:
+2. **Update Properties:** Fill out `properties.yaml` with your real-world Jenkins configs. This "hydrates" the `casc.yaml` template with your actual cluster details and secrets.
+
+3. **Launch the Controller:** Start the container with port mappings for the UI and agent communication. Ensure the persistent volume is mounted:
     ```sh
     podman run -d \
-        --name jenkins-controller \
+        --name ceph-jenkins \
         -p 8080:8080 -p 50000:50000 \
         -v jenkins_home:/var/jenkins_home \
-        -e JENKINS_ADMIN_PASSWORD="<your_secure_password>" \
+        -v $(pwd)/properties.yaml:/var/jenkins_home/casc_configs/02-properties.yaml:z \
         ceph-jenkins-controller:latest
     ```
-3. **Bootstrap Jobs:** Upon startup, JCasC will automatically execute `seed.groovy` to create the `Seed` job.
+4. **Bootstrap Jobs:** Upon startup, JCasC will automatically execute `seed.groovy` to create the `Seed` job.
 
-4. **Process Project Jobs:** Run the `Seed` from the Jenkins UI, providing the relative path to your project's Groovy definitions to generate project-specific pipelines.
+5. **Process Project Jobs:** Run the `Seed` from the Jenkins UI, providing the relative path to your project's Groovy definitions to generate project-specific pipelines.
 
 ### Logging
 

--- a/casc.yaml
+++ b/casc.yaml
@@ -1,6 +1,6 @@
 jenkins:
   systemMessage: "Ceph Jenkins Controller"
-  numExecutors: 1
+  numExecutors: 0
   mode: EXCLUSIVE
 
   # Security configuration
@@ -10,11 +10,44 @@ jenkins:
       users:
         - id: "admin"
           password: "${JENKINS_ADMIN_PASSWORD:-admin123}"
+
   authorizationStrategy:
     globalMatrix:
       permissions:
         - "Overall/Administer:admin"
-        - "Overall/Read:authenticated"
+        - "Overall/Read:anonymous"
+
+  nodes:
+    - permanent:
+        name: "ceph-agent-01"
+        remoteFS: "/home/jenkins"
+        labelString: "teuthology"
+        mode: NORMAL
+        numExecutors: 10
+        launcher:
+          ssh:
+            host: "${CEPH_AGENT_01_IP}"
+            port: 22
+            credentialsId: "ceph-agent-ssh-key"
+            sshHostKeyVerificationStrategy: "nonVerifyingKeyVerificationStrategy"
+
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+          - basicSSHUserPrivateKey:
+              scope: SYSTEM
+              id: "ceph-agent-ssh-key"
+              username: "jenkins"
+              description: "SSH Key for agent nodes"
+              privateKeySource:
+                directEntry:
+                  privateKey: "${SSH_PRIVATE_KEY}"
+
+unclassified:
+  location:
+    url: "${JENKINS_BUILD_URL}"
+    adminAddress: "${JENKINS_ADMIN_EMAIL}
 
 # Seeder job
 jobs:

--- a/plugins.txt
+++ b/plugins.txt
@@ -3,3 +3,4 @@ job-dsl
 git
 workflow-aggregator
 matrix-auth
+ssh-slaves

--- a/properties.yaml
+++ b/properties.yaml
@@ -1,0 +1,31 @@
+jenkins:
+  securityRealm:
+    local:
+      users:
+        - id: "admin"
+          password: "<your_admin_password>"
+
+  nodes:
+    - permanent:
+        name: "ceph-agent-01"
+        launcher:
+          ssh:
+            host: "<ceph_agent_01_ip_address>"
+
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+          - basicSSHUserPrivateKey:
+              id: "ceph-agent-ssh-key"
+              privateKeySource:
+                directEntry:
+                  privateKey: |
+                    -----BEGIN OPENSSH PRIVATE KEY-----
+                    ... <your_full_private_key> ...
+                    -----END OPENSSH PRIVATE KEY-----
+
+unclassified:
+  location:
+    url: "http://<jenkins_(ip_address|url)>:8080/"
+    adminAddress: "<your_admin_email>"


### PR DESCRIPTION
This change introduces `properties.yaml` file for sensitive and site-specific data. This allow  to share the base Jenkins logic across different Ceph test environments while keeping cluster-specific IPs and SSH keys separate.