### PR TITLE
feat: source container builds from Pulp and add build-to-container pipeline trigger

### DIFF
--- a/jobs/pipelines/sample_ceph_build_ci/Jenkinsfile
+++ b/jobs/pipelines/sample_ceph_build_ci/Jenkinsfile
@@ -413,6 +413,39 @@ pipeline {
                 }
             }
         }
+
+        stage("Trigger Ceph Container Image Pipeline") {
+            when {
+                expression {
+                    return params.BUILD_OCI_IMAGES
+                }
+            }
+
+            agent {
+                node {
+                    label "ceph-build-fedora39-agent"
+                }
+            }
+
+            steps {
+                script {
+                    echo "Triggering sample-ceph-container-pipeline ..."
+                    build(
+                        job: "sample-ceph-container-pipeline",
+                        parameters: [
+                            string(name: "CEPH_BRANCH", value: params.CEPH_BRANCH),
+                            string(name: "SHA1", value: env.SHA1),
+                            string(name: "VERSION", value: env.VERSION),
+                            string(name: "DISTRO", value: params.DISTRO),
+                            string(name: "ARCH", value: params.ARCH),
+                            string(name: "FLAVOR", value: params.FLAVOR)
+                        ],
+                        wait: true,
+                        propagate: true
+                    )
+                }
+            }
+        }
     }
 
     post {

--- a/jobs/pipelines/sample_ceph_container_ci/Jenkinsfile
+++ b/jobs/pipelines/sample_ceph_container_ci/Jenkinsfile
@@ -1,26 +1,6 @@
-
-// Function to get the build detail from the Shaman API
-def get_build_details(branch, distro, release, arch, flavor) {
-    // Set the build URL
-    def build_url = "https://shaman.ceph.com/api/repos/ceph/${branch}/latest/${distro}/${release}/"
-
-    // Get the build detail
-    def get_build_detail = sh(script: "curl -s ${build_url}", returnStdout: true).trim()
-
-    // Parse the build detail
-    def build_detail_json = readJSON text: get_build_detail
-
-    // Find the build detail for the given architecture
-    def build_detail = build_detail_json.find {
-        arch in it.archs && it.flavor == flavor
-    }
-
-    // Validate the build detail
-    if (build_detail == null) {
-        error "No build detail found for branch ${branch}"
-    }
-
-    return build_detail
+// Construct the Pulp RPM repository content URL for a given build
+def get_pulp_repo_url(branch, sha1, distro, release, flavor) {
+    return "${env.PULP_SERVER_URL}/pulp/content/repos/ceph/${branch}/${sha1}/${distro}/${release}/flavors/${flavor}/"
 }
 
 // Push a container image to the Pulp registry following official ceph-ci/ceph tag convention:
@@ -129,7 +109,7 @@ pipeline {
 
         stage("Build Ceph Container Image") {
             parallel {
-                stage("Build CentOS9-x86_64 Container Image") {
+                stage("CentOS 9.Stream") {
                     when {
                         allOf {
                             expression {
@@ -158,24 +138,13 @@ pipeline {
                     steps {
                         script {
                             echo "Running Buildah container image build script ..."
-                            
-                            // Get the build details
-                            def build_detail = get_build_details(
-                                params.CEPH_BRANCH, DISTRO, RELEASE, ARCH, params.FLAVOR
+
+                            env.SHA1 = params.SHA1
+                            env.VERSION = params.VERSION
+                            env.REPO_URL = get_pulp_repo_url(
+                                params.CEPH_BRANCH, env.SHA1, DISTRO, RELEASE, params.FLAVOR
                             )
 
-                            // Set the environment variables
-                            env.SHA1 = build_detail.sha1
-                            env.VERSION = build_detail.extra.version
-
-                            // Normalize the repository URL
-                            def chacra_url = build_detail.chacra_url
-                            if (chacra_url.endsWith("/")) {
-                                chacra_url = chacra_url.take(chacra_url.length() - 1)
-                            }
-                            env.REPO_URL = "${chacra_url}/repo"
-
-                            // Execute the build container script
                             dir("${CEPH_DIR}") {
                                 sh "chmod +x ${BUILD_CONTAINER_SCRIPT} && ${BUILD_CONTAINER_SCRIPT}"
                             }
@@ -185,7 +154,7 @@ pipeline {
                     }
                 }
 
-                stage("Build Rocky10-x86_64 Container Image") {
+                stage("Rocky Linux 10") {
                     when {
                         allOf {
                             expression {
@@ -213,23 +182,14 @@ pipeline {
 
                     steps {
                         script {
-                            // Get the build details
-                            def build_detail = get_build_details(
-                                params.CEPH_BRANCH, DISTRO, RELEASE, ARCH, params.FLAVOR
+                            echo "Running Buildah container image build script ..."
+
+                            env.SHA1 = params.SHA1
+                            env.VERSION = params.VERSION
+                            env.REPO_URL = get_pulp_repo_url(
+                                params.CEPH_BRANCH, env.SHA1, DISTRO, RELEASE, params.FLAVOR
                             )
 
-                            // Set the environment variables
-                            env.SHA1 = build_detail.sha1
-                            env.VERSION = build_detail.extra.version
-
-                            // Normalize the repository URL
-                            def chacra_url = build_detail.chacra_url
-                            if (chacra_url.endsWith("/")) {
-                                chacra_url = chacra_url.take(chacra_url.length() - 1)
-                            }
-                            env.REPO_URL = "${chacra_url}/repo"
-
-                            // Execute the build container script
                             dir("${CEPH_DIR}") {
                                 sh "chmod +x ${BUILD_CONTAINER_SCRIPT} && ${BUILD_CONTAINER_SCRIPT}"
                             }

--- a/jobs/pipelines/sample_ceph_container_ci/build_container.sh
+++ b/jobs/pipelines/sample_ceph_container_ci/build_container.sh
@@ -12,8 +12,20 @@ sudo buildah run $CEPH_CNTR -- dnf install -y epel-release dnf-plugins-core
 # Enable CodeReady Builder (CRB) for Ceph build dependencies
 sudo buildah run $CEPH_CNTR -- dnf config-manager --set-enabled crb
 
-# Fetch repo file from $REPO_URL and add to /etc/yum.repos.d/ceph.repo
-sudo buildah run $CEPH_CNTR -- curl -sL "${REPO_URL}" -o /etc/yum.repos.d/ceph.repo
+# Create yum repo files pointing to the Pulp repository (x86_64 + noarch)
+sudo buildah run $CEPH_CNTR -- bash -c "cat > /etc/yum.repos.d/ceph.repo <<EOF
+[ceph-x86_64]
+name=Ceph Packages - x86_64
+baseurl=${REPO_URL}x86_64/
+enabled=1
+gpgcheck=0
+
+[ceph-noarch]
+name=Ceph Packages - noarch
+baseurl=${REPO_URL}noarch/
+enabled=1
+gpgcheck=0
+EOF"
 
 # Install Ceph packages
 sudo buildah run $CEPH_CNTR -- dnf install -y ceph ceph-common ceph-osd ceph-mon ceph-mgr

--- a/jobs/sample_ceph_build_ci.groovy
+++ b/jobs/sample_ceph_build_ci.groovy
@@ -31,6 +31,11 @@ pipelineJob("sample-ceph-pipeline") {
             )
             stringParam("DEB_BUILD_OPTS", "", "Additional DEB build options")
             booleanParam("PUBLISH_ARTIFACTS", true, "Publish built packages to Pulp")
+            booleanParam(
+                "BUILD_OCI_IMAGES",
+                false,
+                "Run sample-ceph-container-pipeline after this build (build and push container images to Pulp)"
+            )
         }
     }
 }

--- a/jobs/sample_ceph_container_ci.groovy
+++ b/jobs/sample_ceph_container_ci.groovy
@@ -19,6 +19,8 @@ pipelineJob("sample-ceph-container-pipeline") {
         // Add the required parameters for the job
         parameters {
             stringParam("CEPH_BRANCH", "main", "Ceph branch to build")
+            stringParam("SHA1", "", "Git SHA1 of the Ceph build (from the build pipeline)")
+            stringParam("VERSION", "", "Ceph version string (from the build pipeline)")
             stringParam("DISTRO", "centos9 rocky10", "Distribution to build")
             stringParam("ARCH", "x86_64", "Architecture to build")
             choiceParam("FLAVOR", ["default"], "Build flavor")


### PR DESCRIPTION
**Summary**

- Replace Shaman/Chacra with Pulp as the package source for the container pipeline, so container images are built from the same packages the build pipeline publishes
- Add a TRIGGER_CONTAINER_PIPELINE parameter to the build pipeline that automatically triggers the container pipeline with SHA1 and VERSION after packages are published
- Update build_container.sh to create yum repo entries (x86_64 + noarch) pointing to the Pulp content URL instead of curling a .repo file from Chacra